### PR TITLE
fix: discover skillkit installed via mise

### DIFF
--- a/src/skillkit.ts
+++ b/src/skillkit.ts
@@ -19,6 +19,14 @@ function buildPath(): string {
 			extra.push(join(nvmDir, d, "bin"));
 		}
 	} catch { /* empty */ }
+	const miseDir = join(HOME, ".local", "share", "mise", "installs");
+	for (const runtime of ["node", "bun"]) {
+		try {
+			for (const d of readdirSync(join(miseDir, runtime))) {
+				extra.push(join(miseDir, runtime, d, "bin"));
+			}
+		} catch { /* empty */ }
+	}
 	return [...extra, process.env.PATH || ""].join(":");
 }
 
@@ -35,6 +43,13 @@ function findSkillkitBin(): string | null {
 	try {
 		for (const d of readdirSync(nvmDir)) {
 			const p = join(nvmDir, d, "bin", "skillkit");
+			if (existsSync(p)) return p;
+		}
+	} catch { /* empty */ }
+	const miseNodeDir = join(HOME, ".local", "share", "mise", "installs", "node");
+	try {
+		for (const d of readdirSync(miseNodeDir)) {
+			const p = join(miseNodeDir, d, "bin", "skillkit");
 			if (existsSync(p)) return p;
 		}
 	} catch { /* empty */ }


### PR DESCRIPTION
## Summary

- Add `~/.local/share/mise/installs/node/*/bin` to both `findSkillkitBin()` and `buildPath()`, matching the existing nvm discovery pattern
- Without this, users who install skillkit through [mise](https://mise.jdx.dev/) see an empty dashboard — `isSkillkitAvailable()` returns `true` (the analytics DB exists) but every `runSkillkitJson()` call returns `null` because the binary is never found

Fixes #1

## Test plan

- [ ] Install skillkit via mise (`mise use -g node@22 && npm i -g @crafter/skillkit`)
- [ ] Verify `~/.local/share/mise/installs/node/*/bin/skillkit` exists
- [ ] Open Agentfiles → Dashboard and confirm it renders stats