### PR TITLE
feat: enable text selection in detail panel

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -263,6 +263,8 @@
 	padding: 10px 16px 8px;
 	border-bottom: 1px solid var(--background-modifier-border);
 	flex-shrink: 0;
+	-webkit-user-select: text;
+	user-select: text;
 }
 
 .as-toolbar-top {
@@ -409,6 +411,9 @@
 	flex: 1;
 	overflow-y: auto;
 	min-height: 0;
+	-webkit-user-select: text;
+	user-select: text;
+	cursor: text;
 }
 
 .as-detail-preview {


### PR DESCRIPTION
## Summary
- Adds `user-select: text` and `cursor: text` to the detail panel header and content area so users can select and copy skill content

## Test plan
- [ ] Open any skill in the detail panel
- [ ] Verify you can click-drag to select text in the header and content areas
- [ ] Verify copy (Cmd+C) works on selected text

🤖 Generated with [Claude Code](https://claude.com/claude-code)